### PR TITLE
Improve tracks menu UI speed

### DIFF
--- a/application/vlc-android/res/layout-land/player_overlay_tracks.xml
+++ b/application/vlc-android/res/layout-land/player_overlay_tracks.xml
@@ -35,7 +35,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <LinearLayout
                 android:id="@+id/player_overlay_tracks"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -46,50 +46,36 @@
                     android:id="@+id/audio_tracks"
                     layout="@layout/player_overlay_track_item"
                     android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    app:layout_constraintEnd_toStartOf="@+id/tracks_separator_2"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    android:layout_weight="1"
+                    android:layout_height="wrap_content" />
 
             <View
                     android:id="@+id/tracks_separator_2"
                     android:layout_width="1dp"
-                    android:layout_height="0dp"
+                    android:layout_height="match_parent"
                     android:background="@color/white_transparent_10"
-                    android:focusable="false"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toStartOf="@+id/subtitle_tracks"
-                    app:layout_constraintStart_toEndOf="@+id/audio_tracks"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    android:focusable="false" />
 
             <include
                     android:id="@+id/subtitle_tracks"
                     layout="@layout/player_overlay_track_item"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    app:layout_constraintEnd_toStartOf="@+id/tracks_separator_3"
-                    app:layout_constraintStart_toEndOf="@+id/tracks_separator_2"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    android:layout_weight="1" />
 
             <View
                     android:id="@+id/tracks_separator_3"
                     android:layout_width="1dp"
-                    android:layout_height="0dp"
+                    android:layout_height="match_parent"
                     android:background="@color/white_transparent_10"
-                    android:focusable="false"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toStartOf="@+id/video_tracks"
-                    app:layout_constraintStart_toEndOf="@+id/subtitle_tracks"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    android:focusable="false" />
 
             <include
                     android:id="@+id/video_tracks"
                     layout="@layout/player_overlay_track_item"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toEndOf="@+id/tracks_separator_3"
-                    app:layout_constraintTop_toTopOf="parent" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                    android:layout_weight="1" />
+        </LinearLayout>
     </androidx.core.widget.NestedScrollView>
 </layout>

--- a/application/vlc-android/res/layout-land/player_overlay_tracks.xml
+++ b/application/vlc-android/res/layout-land/player_overlay_tracks.xml
@@ -70,9 +70,9 @@
                     android:background="@color/white_transparent_10"
                     android:focusable="false" />
 
-            <include
+            <ViewStub
                     android:id="@+id/video_tracks"
-                    layout="@layout/player_overlay_track_item"
+                    android:layout="@layout/player_overlay_track_item"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1" />

--- a/application/vlc-android/res/layout/player_overlay_track_item.xml
+++ b/application/vlc-android/res/layout/player_overlay_track_item.xml
@@ -31,73 +31,59 @@
 
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
+            android:orientation="vertical"
             android:id="@+id/track_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-        <TextView
-                android:id="@+id/empty_view"
-                android:layout_width="wrap_content"
-                android:layout_height="50dp"
-                android:layout_marginTop="24dp"
-                android:gravity="center_vertical"
-                android:text="@string/no_track"
-                android:textAlignment="center"
-                android:textColor="@color/white_transparent_50"
-                android:visibility="gone"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/options_container"
-                tools:visibility="visible" />
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
 
-        <TextView
-                android:id="@+id/track_title"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="16dp"
-                android:layout_marginTop="16dp"
-                android:layout_marginEnd="8dp"
-                android:text="@string/subtitles"
-                android:textColor="@color/white"
-                android:textSize="16sp"
-                app:layout_constraintEnd_toStartOf="@id/track_more"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-        <ImageView
+            <ImageView
                 android:id="@+id/track_more"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:padding="8dp"
-                android:focusable="true"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:layout_gravity="end|center_vertical"
                 android:background="?attr/selectableItemBackgroundBorderless"
-                app:layout_constraintBottom_toBottomOf="@id/track_title"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@id/track_title"
+                android:focusable="true"
+                android:padding="8dp"
                 app:srcCompat="@drawable/ic_collapse_arrow" />
 
-        <FrameLayout
+            <TextView
+                android:id="@+id/track_title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:id="@+id/options_container"
-                app:layout_constraintTop_toBottomOf="@+id/track_title">
-
-            <org.videolan.vlc.gui.view.CollapsibleLinearLayout
-                    android:id="@+id/options"
-                    android:layout_width="match_parent"
-                    android:layout_height="0dp"
-                    android:orientation="vertical" />
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="56dp"
+                android:text="@string/subtitles"
+                android:textColor="@color/white"
+                android:textSize="16sp" />
         </FrameLayout>
 
+        <org.videolan.vlc.gui.view.CollapsibleLinearLayout
+            android:id="@+id/options"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="16dp"
+            android:orientation="vertical" />
+
+        <TextView
+            android:id="@+id/empty_view"
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:layout_marginTop="24dp"
+            android:text="@string/no_track"
+            android:textAlignment="center"
+            android:textColor="@color/white_transparent_50"
+            android:visibility="gone" />
+
         <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/track_list"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/options_container" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            android:id="@+id/track_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
 
 </layout>

--- a/application/vlc-android/res/layout/player_overlay_track_item.xml
+++ b/application/vlc-android/res/layout/player_overlay_track_item.xml
@@ -87,7 +87,7 @@
             <org.videolan.vlc.gui.view.CollapsibleLinearLayout
                     android:id="@+id/options"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                    android:layout_height="0dp"
                     android:orientation="vertical" />
         </FrameLayout>
 

--- a/application/vlc-android/res/layout/player_overlay_track_item.xml
+++ b/application/vlc-android/res/layout/player_overlay_track_item.xml
@@ -25,12 +25,6 @@
         xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools">
 
-    <data>
-
-        <import type="android.view.View" />
-
-    </data>
-
     <LinearLayout
             android:orientation="vertical"
             android:id="@+id/track_container"

--- a/application/vlc-android/res/layout/player_overlay_tracks.xml
+++ b/application/vlc-android/res/layout/player_overlay_tracks.xml
@@ -92,9 +92,9 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/subtitle_tracks" />
 
-            <include
+            <ViewStub
                     android:id="@+id/video_tracks"
-                    layout="@layout/player_overlay_track_item"
+                    android:layout="@layout/player_overlay_track_item"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     app:layout_constraintBottom_toBottomOf="parent"

--- a/application/vlc-android/res/layout/video_track_item.xml
+++ b/application/vlc-android/res/layout/video_track_item.xml
@@ -17,47 +17,38 @@
                 type="Boolean" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
+            android:id="@+id/track_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="?android:attr/selectableItemBackground"
             android:focusable="true"
-            android:id="@+id/track_container"
             android:minHeight="50dp"
+            android:orientation="horizontal"
             android:paddingStart="16dp"
             android:paddingEnd="16dp">
 
 
         <ImageView
                 android:id="@+id/imageView11"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toStartOf="@+id/track_title"
-                app:layout_constraintHorizontal_bias="0.5"
+                android:layout_width="28dp"
+                android:layout_height="28dp"
+                android:layout_gravity="center_vertical"
                 android:visibility="@{selected ? View.VISIBLE : View.INVISIBLE}"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
                 app:srcCompat="@drawable/ic_delay_done" />
 
         <TextView
                 android:id="@+id/track_title"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
                 android:layout_marginStart="16dp"
-                android:text="@{track.name}"
-                android:textColor="@{selected ? @color/white : @color/white_transparent_50}"
                 android:maxLines="1"
                 android:singleLine="true"
+                android:text="@{track.name}"
+                android:textColor="@{selected ? @color/white : @color/white_transparent_50}"
                 app:ellipsizeMode="@{true}"
                 app:selected="@{selected}"
-                app:layout_constraintBottom_toBottomOf="@+id/imageView11"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.5"
-                app:layout_constraintHorizontal_chainStyle="spread"
-                app:layout_constraintStart_toEndOf="@+id/imageView11"
-                app:layout_constraintTop_toTopOf="@+id/imageView11"
                 tools:text="Audio 1 {FR]" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
 </layout>

--- a/application/vlc-android/src/org/videolan/vlc/gui/dialogs/VideoTracksDialog.kt
+++ b/application/vlc-android/src/org/videolan/vlc/gui/dialogs/VideoTracksDialog.kt
@@ -50,6 +50,7 @@ import org.videolan.vlc.R
 import org.videolan.vlc.databinding.PlayerOverlayTracksBinding
 import org.videolan.vlc.gui.dialogs.adapters.TrackAdapter
 import org.videolan.vlc.gui.helpers.getBitmapFromDrawable
+import org.videolan.vlc.gui.video.VideoPlayerActivity
 
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
@@ -108,9 +109,38 @@ class VideoTracksDialog : VLCBottomSheetDialogFragment() {
         }
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
         binding = PlayerOverlayTracksBinding.inflate(layoutInflater, container, false)
+        val start = System.currentTimeMillis()
+        binding.root.addOnLayoutChangeListener(OnLayoutListener(start))
         return binding.root
+    }
+
+    internal inner class OnLayoutListener(private val start: Long) : View.OnLayoutChangeListener {
+        override fun onLayoutChange(
+            v: View,
+            left: Int,
+            top: Int,
+            right: Int,
+            bottom: Int,
+            oldLeft: Int,
+            oldTop: Int,
+            oldRight: Int,
+            oldBottom: Int
+        ) {
+            if (v.visibility == View.VISIBLE) {
+                val end = System.currentTimeMillis()
+                val animTime = end - start
+                println("VideoTracks UI appearing time: $animTime")
+                val activity = requireActivity() as VideoPlayerActivity
+                println("from click to VideoTracks UI appearing: ${end - activity.audioClickTime}")
+                v.removeOnLayoutChangeListener(this)
+            }
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/application/vlc-android/src/org/videolan/vlc/gui/dialogs/VideoTracksDialog.kt
+++ b/application/vlc-android/src/org/videolan/vlc/gui/dialogs/VideoTracksDialog.kt
@@ -33,6 +33,7 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
+import androidx.core.view.isEmpty
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_EXPANDED
@@ -159,30 +160,36 @@ class VideoTracksDialog : VLCBottomSheetDialogFragment() {
         binding.tracksSeparator2.isEnabled = false
 
 
-
-        generateSeparator(binding.audioTracks.options)
-        generateOptionItem(binding.audioTracks.options, getString(R.string.audio_delay), R.drawable.ic_delay, VideoTrackOption.AUDIO_DELAY)
-        generateSeparator(binding.audioTracks.options, true)
         binding.audioTracks.options.setAnimationUpdateListener {
             binding.audioTracks.trackMore.rotation = if (binding.audioTracks.options.isCollapsed) 180F - (180F * it) else 180F * it
         }
 
-
-        generateSeparator(binding.subtitleTracks.options)
-        generateOptionItem(binding.subtitleTracks.options, getString(R.string.spu_delay), R.drawable.ic_delay, VideoTrackOption.SUB_DELAY)
-        generateOptionItem(binding.subtitleTracks.options, getString(R.string.subtitle_select), R.drawable.ic_subtitles_file, VideoTrackOption.SUB_PICK)
-        generateOptionItem(binding.subtitleTracks.options, getString(R.string.download_subtitles), R.drawable.ic_download, VideoTrackOption.SUB_DOWNLOAD)
-        generateSeparator(binding.subtitleTracks.options, true)
         binding.subtitleTracks.options.setAnimationUpdateListener {
             binding.subtitleTracks.trackMore.rotation = if (binding.subtitleTracks.options.isCollapsed) 180F - (180F * it) else 180F * it
         }
 
         binding.audioTracks.trackMore.setOnClickListener {
+            val options = binding.audioTracks.options
+            if (options.isEmpty()) {
+                generateSeparator(options)
+                generateOptionItem(options, getString(R.string.audio_delay), R.drawable.ic_delay, VideoTrackOption.AUDIO_DELAY)
+                generateSeparator(options, true)
+            }
+
             binding.audioTracks.options.toggle()
             binding.subtitleTracks.options.collapse()
         }
 
         binding.subtitleTracks.trackMore.setOnClickListener {
+            val options = binding.subtitleTracks.options
+            if (options.isEmpty()) {
+                generateSeparator(options)
+                generateOptionItem(options, getString(R.string.spu_delay), R.drawable.ic_delay, VideoTrackOption.SUB_DELAY)
+                generateOptionItem(options, getString(R.string.subtitle_select), R.drawable.ic_subtitles_file, VideoTrackOption.SUB_PICK)
+                generateOptionItem(options, getString(R.string.download_subtitles), R.drawable.ic_download, VideoTrackOption.SUB_DOWNLOAD)
+                generateSeparator(options, true)
+            }
+
             binding.subtitleTracks.options.toggle()
             binding.audioTracks.options.collapse()
         }

--- a/application/vlc-android/src/org/videolan/vlc/gui/video/VideoPlayerActivity.kt
+++ b/application/vlc-android/src/org/videolan/vlc/gui/video/VideoPlayerActivity.kt
@@ -1605,7 +1605,10 @@ open class VideoPlayerActivity : AppCompatActivity(), PlaybackService.Callback, 
         window.attributes = lp
     }
 
+    var audioClickTime = 0L
+
     open fun onAudioSubClick(anchor: View?) {
+        audioClickTime = System.currentTimeMillis()
         overlayDelegate.showTracks()
         overlayDelegate.hideOverlay(false)
     }

--- a/application/vlc-android/src/org/videolan/vlc/gui/view/CollapsibleLinearLayout.kt
+++ b/application/vlc-android/src/org/videolan/vlc/gui/view/CollapsibleLinearLayout.kt
@@ -27,6 +27,7 @@ package org.videolan.vlc.gui.view
 import android.animation.ValueAnimator
 import android.content.Context
 import android.util.AttributeSet
+import android.view.View
 import android.view.ViewTreeObserver.OnGlobalLayoutListener
 import android.view.animation.AccelerateInterpolator
 import android.widget.LinearLayout
@@ -71,15 +72,10 @@ class CollapsibleLinearLayout : LinearLayout {
 
     private fun initialize() {
         if (layoutParams is ConstraintLayout.LayoutParams) throw IllegalStateException("The parent should not be a ConstraintLayout to prevent height issues (when set to 0)")
-        viewTreeObserver.addOnGlobalLayoutListener(
-                object : OnGlobalLayoutListener {
-                    override fun onGlobalLayout() {
-                        maxHeight = height
-                        viewTreeObserver.removeOnGlobalLayoutListener(this)
-                        layoutParams.height = 0
-                        requestLayout()
-                    }
-                })
+        post {
+            measure(MeasureSpec.makeMeasureSpec((parent as View).width, MeasureSpec.EXACTLY), 0)
+            maxHeight = measuredHeight
+        }
     }
 
     fun toggle() {

--- a/application/vlc-android/src/org/videolan/vlc/gui/view/CollapsibleLinearLayout.kt
+++ b/application/vlc-android/src/org/videolan/vlc/gui/view/CollapsibleLinearLayout.kt
@@ -72,13 +72,13 @@ class CollapsibleLinearLayout : LinearLayout {
 
     private fun initialize() {
         if (layoutParams is ConstraintLayout.LayoutParams) throw IllegalStateException("The parent should not be a ConstraintLayout to prevent height issues (when set to 0)")
-        post {
-            measure(MeasureSpec.makeMeasureSpec((parent as View).width, MeasureSpec.EXACTLY), 0)
-            maxHeight = measuredHeight
-        }
     }
 
     fun toggle() {
+        if (maxHeight == -1) {
+            measure(MeasureSpec.makeMeasureSpec((parent as View).width, MeasureSpec.EXACTLY), 0)
+            maxHeight = measuredHeight
+        }
         val fromHeight = if (!isCollapsed) maxHeight else 0
         val toHeight = if (!isCollapsed) 0 else maxHeight
         isCollapsed = !isCollapsed


### PR DESCRIPTION
Closes https://github.com/PDApps/DICTI/issues/176

Время от клика до появления интерфейса в ландшафтной ориентации (3 варианта аудио, 2 варианта субтитров) / время от onCreate до появления UI. Was:
```
Samsung Note 4 (debug) ~195 ms / ~170 ms
Xiaomi 11T, Android 12 (debug) ~258 ms / ~226 ms
```
Now it:
```
Samsung Note 4 (debug) ~143 ms / ~121 ms
Xiaomi 11T, Android 12 (debug) ~237 ms / ~178 ms
```

<details>
  <summary>Note 4 profiler</summary>

[Note_4_tracks_land_commit_1_cpu-art-20220525T160612.zip](https://github.com/PDApps/vlc-android/files/8771378/Note_4_tracks_land_commit_1_cpu-art-20220525T160612.zip)
![Screenshot from 2022-05-25 16-06-04](https://user-images.githubusercontent.com/4016063/170269091-e03f3593-50b2-4420-afc0-11a437fcbafb.png)

</details>

Во время профайлинга на t11 я заметил, что UI появляется сначала на мгновение в раскрытом виде, а потом в свернутом варианте. По профайлеру тоже видно, что после первого расчета UI запускается ещё один прощет.  
<details>
  <summary>T11 profiler</summary>

[t11_tracks_land_commit_1_cpu-art-20220525T161626.zip](https://github.com/PDApps/vlc-android/files/8771458/t11_tracks_land_commit_1_cpu-art-20220525T161626.zip)
![Screenshot from 2022-05-25 16-16-14](https://user-images.githubusercontent.com/4016063/170271259-0028804a-8041-4639-8e3d-1fc5e3ae60bd.png)

</details>

Исправил мелькание https://github.com/PDApps/vlc-android/pull/1/commits/8af12596c7995551b528364c2195a748dfc39673 (панели иногда появлялись сначала в развернутом состоянии).
Заменил ещё один `ConstraintLayout` 209406a0883c02b41c6b4f5d47373b9aa36cbd6e.
```
Samsung Note 4 (debug) ~129 ms / ~107 ms
Samsung Note 4 (release) ~208 ms / ~177 ms
Xiaomi 11T, Android 12 (debug) ~220 ms / ~175 ms (55-330 ms)
Xiaomi 11T, Android 12 (release) ~206 ms (150-300 ms) / ~158 ms (60-260 ms)
```
<details>
  <summary>Note 4 profiler</summary>

[Note_4_tracks_land_commit_3_cpu-art-20220526T093148.zip](https://github.com/PDApps/DICTI/files/8776818/Note_4_tracks_land_commit_3_cpu-art-20220526T093148.zip)
![Screenshot from 2022-05-26 09-25-48](https://user-images.githubusercontent.com/4016063/170431591-a4c4fca6-aa4b-407e-9957-30d9b9316719.png)

</details>

<details>
  <summary>T11 profiler</summary>

[t11_tracks_land_commit_3_cpu-art-20220526T094634.zip](https://github.com/PDApps/vlc-android/files/8776886/t11_tracks_land_commit_3_cpu-art-20220526T094634.zip)
![Screenshot from 2022-05-26 09-46-20](https://user-images.githubusercontent.com/4016063/170433337-90dc2a05-f64f-4dbb-80a7-ab3e013fb8ba.png)

</details>

По профайлеру видно, что в Note 4 появилось ещё одна секция `measure`. Думаю, это из-за моего исправления 8af12596c7995551b528364c2195a748dfc39673. Я там специально вызываю `measure`, чтобы узнать высоту панелей. До этого приложение дожидалось пока просчитаются размеры панели в раскрытом состоянии, и только потом устанавливало нулевую высоту. На t11 наоборот пропал один кусок `measure` в конце.
Я временно удалил свой `measure`, но вторая секция `measure` осталась в Note 4. Это не мой `measure` был. Что-то странное, буду в первую очередь ориентироваться на замеры производительности. Ещё я обнаружил, что старая и новая версия профайлера показывают немного разные данные.

Сдалал, чтобы опции создавались при первом их показе, а не при создании главного диалога.
```
Samsung Note 4 (debug) ~112 ms / ~92 ms
```
<details>
  <summary>Note 4 profiler</summary>

[Note_4_tracks_land_commit_4_cpu-art-20220526T115212.zip](https://github.com/PDApps/vlc-android/files/8777855/Note_4_tracks_land_commit_4_cpu-art-20220526T115212.zip)
![Screenshot from 2022-05-26 11-52-02](https://user-images.githubusercontent.com/4016063/170458276-9d644cdf-aede-4e4f-8e77-bb4ab5ad7350.png)

</details>

<details>
  <summary>T11 profiler</summary>

[t11_tracks_land_commit_4_cpu-art-20220526T120053.zip](https://github.com/PDApps/vlc-android/files/8777853/t11_tracks_land_commit_4_cpu-art-20220526T120053.zip)
![Screenshot from 2022-05-26 12-00-28](https://user-images.githubusercontent.com/4016063/170458294-0b4e154b-1495-4f2e-81e0-33b169f0d6f0.png)

</details>

Вынес секцию с вариантами видео в `ViewStub`, так как в 99% случаев она все равно будет спрятана.
```
Samsung Note 4 (debug) ~99 ms / ~81 ms
Samsung Note 4 (release) ~142 ms / ~120 ms
Xiaomi 11T, Android 12 (release) ~199 ms (95-330 ms) / не считал вторую цифру, так как пока считаю первую все логи почему-то затираются. Да и разброс значений на T11 огромный (минимальное значение отличается от максимального в несколько раз), что не способствует пониманию, улучшилось что-то или нет. На Note 4 разброс значений +-20%.
Xiaomi 11T, Android 12 (release) ещё раз протестировал ~239 ms (160-330 ms)
```

<details>
  <summary>Note 4 profiler</summary>

[Note_4_tracks_land_commit_5_cpu-art-20220526T145604.zip](https://github.com/PDApps/vlc-android/files/8778732/Note_4_tracks_land_commit_5_cpu-art-20220526T145604.zip)
![Screenshot from 2022-05-26 14-55-54](https://user-images.githubusercontent.com/4016063/170483565-294cc624-1344-4bef-8a9f-0dbf526011ff.png)
</details>

